### PR TITLE
Fixes typo in attribute of DremioClonerConfig class

### DIFF
--- a/src/DremioClonerConfig.py
+++ b/src/DremioClonerConfig.py
@@ -152,7 +152,7 @@ class DremioClonerConfig():
 	_space_folder_exclude_filter_re = None
 	_space_folder_cascade_acl_origin_filter_re = None
 	_source_filter_re = None
-	_source_exluce_filter_re = None
+	_source_exclude_filter_re = None
 	_source_folder_filter_re = None
 	_source_folder_exclude_filter_re = None
 	_pds_filter_re = None


### PR DESCRIPTION
This PR fixes a bug in the GET command where the configs can not be directly converted to the ConfigClass


Original StackTrace
```
Traceback (most recent call last):
  File "/home/jeff/dev/dremio-cloner/src/dremio_cloner.py", line 159, in <module>
    main()
  File "/home/jeff/dev/dremio-cloner/src/dremio_cloner.py", line 47, in main
    get_dremio_environment(config)
  File "/home/jeff/dev/dremio-cloner/src/dremio_cloner.py", line 78, in get_dremio_environment
    dremio_data = reader.read_dremio_environment()
  File "/home/jeff/dev/dremio-cloner/src/DremioReader.py", line 54, in read_dremio_environment
    self._read_catalog()
  File "/home/jeff/dev/dremio-cloner/src/DremioReader.py", line 86, in _read_catalog
    self._process_container(container)
  File "/home/jeff/dev/dremio-cloner/src/DremioReader.py", line 100, in _process_container
    self._read_source(container)
  File "/home/jeff/dev/dremio-cloner/src/DremioReader.py", line 149, in _read_source
    if self._filter.match_source_filter(container):
  File "/home/jeff/dev/dremio-cloner/src/DremioClonerFilter.py", line 104, in match_source_filter
    if self._match_path(self._config._source_filter_re, self._config._source_exclude_filter_re, None, None, None, None, container):
AttributeError: 'DremioClonerConfig' object has no attribute '_source_exclude_filter_re'. Did you mean: '_source_excluce_filter_re'?
```