### PR TITLE
Adds some defensive checks when list_reflection call fails (on commun…

### DIFF
--- a/src/DremioWriter.py
+++ b/src/DremioWriter.py
@@ -209,7 +209,8 @@ class DremioWriter:
 
 	def _read_target_reflections(self):
 		self._logger.debug("_read_target_reflections")
-		self._target_reflections = self._dremio_env.list_reflections()['data']
+		reflections = self._dremio_env.list_reflections()
+		self._target_reflections = reflections['data'] if reflections is not None else []
 
 	def _read_target_folders_and_vds_list(self):
 		containers = self._dremio_env.list_catalog()['data']


### PR DESCRIPTION
This PR adds some checks to prevent the script from breaking when connecting to a Community Edition Server which lacks the /api/v3/reflections endpoint. 

Original Stacktrace
```
Traceback (most recent call last):
  File "/home/jeff/dev/dremio-cloner/src/dremio_cloner.py", line 159, in <module>
    main()
  File "/home/jeff/dev/dremio-cloner/src/dremio_cloner.py", line 49, in main
    put_dremio_environment(config)
  File "/home/jeff/dev/dremio-cloner/src/dremio_cloner.py", line 96, in put_dremio_environment
    writer.write_dremio_environment()
  File "/home/jeff/dev/dremio-cloner/src/DremioWriter.py", line 82, in write_dremio_environment
    self._read_target_reflections()
  File "/home/jeff/dev/dremio-cloner/src/DremioWriter.py", line 214, in _read_target_reflections
    return self._dremio_env.list_reflections()["data"]
TypeError: 'NoneType' object is not subscriptable
```