### PR TITLE
Improved PR reviews by splitting up virtual datasets in a metadata file and a SQL file

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The command is configured with a JSON file with configuration attributes listed 
   - &quot;filename&quot;
   - &quot;directory&quot;
   - &quot;overwrite&quot;
+  - &quot;separate_sql_and_metadata_files&quot;
 - &quot;options&quot;:
   - logging options 
     - &quot;logging.level&quot;
@@ -405,6 +406,7 @@ Note, that this command does not provide any option for Scope definition. Please
 | filename | Defines a JSON filename to be used as either source of information for **put** command or target for saving data for **get** command. The JSON file will encapsulate entire information on a Dremio environment. Either _filename_ or _directory_ must be defined.|
 | directory | Similar to filename above. However, a folder structure, identical to Dremio environment will be created and the information on a Dremio objects will be stored in sepearate files within this folder structure. This option allows for use cases with indivudal processing of Dremio objects by external tools, such as github. |
 | overwrite | Allows to overwrite existing JSON file or directory. |
+| separate_sql_and_metadata_files | Per VDS create a JSON metadata file and a SQL file with the VDS definition (only applicable when a directory is set). This option allows more efficient management of changes in code editors and improves readability of the SQL queries. |
 
 ### Logging options
 

--- a/config/config_read.json
+++ b/config/config_read.json
@@ -10,7 +10,9 @@
   },
   {"target": [
 	{"filename":"<TARGET_JSON_FILE_NAME>"},
-	{"overwrite": "False"}]
+	{"overwrite": "False"},
+	{"separate_sql_and_metadata_files": "False"}
+  ]
   },
   {"options": [
 	{"logging.level":"logging.DEBUG"},

--- a/config/config_read_dir.json
+++ b/config/config_read_dir.json
@@ -10,7 +10,9 @@
   },
   {"target": [
 	{"directory":"<TARGET_DIRECTORY_PATH>"},
-	{"overwrite": "False"}]
+	{"overwrite": "False"},
+	{"separate_sql_and_metadata_files": "False"}
+    ]
   },
   {"options": [
 	{"logging.level":"logging.DEBUG"},

--- a/src/DremioClonerConfig.py
+++ b/src/DremioClonerConfig.py
@@ -64,6 +64,7 @@ class DremioClonerConfig():
 	target_filename = None
 	target_directory = None
 	target_file_or_dir_overwrite = False
+	target_separate_sql_and_metadata_files = False
 	target_type = None
 	target_dremio_cloud = False
 	target_dremio_cloud_org_id = None
@@ -234,6 +235,8 @@ class DremioClonerConfig():
 				self.target_directory = item['directory']
 			elif 'overwrite' in item:
 				self.target_file_or_dir_overwrite = self._bool(item, 'overwrite')
+			elif 'separate_sql_and_metadata_files' in item:
+				self.target_separate_sql_and_metadata_files = self._bool(item, 'separate_sql_and_metadata_files')
 			elif 'verify_ssl' in item:
 				self.target_verify_ssl = self._bool(item, 'verify_ssl')
 			elif 'is_community_edition' in item:

--- a/src/DremioFile.py
+++ b/src/DremioFile.py
@@ -242,7 +242,8 @@ class DremioFile():
 			if self._config.vds_process_mode == 'process':
 				for vds in dremio_data.vds_list:
 					self._write_entity_json_file(os.path.join(target_directory, "spaces"), vds)
-					self._write_entity_sql_file(os.path.join(target_directory, "spaces"), vds)
+					if self._config.target_separate_sql_and_metadata_files is True:
+						self._write_entity_sql_file(os.path.join(target_directory, "spaces"), vds)
 			if self._config.pds_process_mode == 'process':
 				for pds in dremio_data.pds_list:
 					self._write_entity_json_file(os.path.join(target_directory, "sources"), pds)
@@ -318,7 +319,7 @@ class DremioFile():
 							container_list.append(data)
 					else:
 						object_list.append(data)
-				elif filename.endswith('.sql'):
+				elif filename.endswith('.sql'): # only has effect if target_separate_sql_and_metadata_files is True
 					try:
 						entity_data = next(filter(lambda x: x['path'][-1] == filename.replace('.sql', ''), object_list))
 						with open(os.path.join(dirpath, filename), 'r') as f:
@@ -397,11 +398,11 @@ class DremioFile():
 		filepath = self._build_path(root_dir=root_dir, path_parts=path_parts, file_extension=".json")
 		filepath.parent.mkdir(parents=True, exist_ok=True)
 		
-		
-		# remove the sql, because that will be saved in a separate file
 		entity_data = copy.copy(entity)
-		if 'sql' in entity_data:
-			del entity_data['sql']
+		if self._config.target_separate_sql_and_metadata_files is True:
+			# remove the sql, because that will be saved in a separate file
+			if 'sql' in entity_data:
+				del entity_data['sql']
 
 		with filepath.open('w', encoding="utf-8") as f:
 			json.dump(entity_data, f, indent=4, sort_keys=True)

--- a/src/DremioFile.py
+++ b/src/DremioFile.py
@@ -22,6 +22,8 @@ import json
 import logging
 import os, errno
 from shutil import rmtree
+import pathlib
+import copy
 
 class DremioFile():
 
@@ -240,6 +242,7 @@ class DremioFile():
 			if self._config.vds_process_mode == 'process':
 				for vds in dremio_data.vds_list:
 					self._write_entity_json_file(os.path.join(target_directory, "spaces"), vds)
+					self._write_entity_sql_file(os.path.join(target_directory, "spaces"), vds)
 			if self._config.pds_process_mode == 'process':
 				for pds in dremio_data.pds_list:
 					self._write_entity_json_file(os.path.join(target_directory, "sources"), pds)
@@ -302,18 +305,28 @@ class DremioFile():
 	def _collect_directory(self, directory, container_list, folder_list, object_list):
 		for (dirpath, dirnames, filenames) in os.walk(directory):
 			for filename in filenames:
-				f = open(os.path.join(dirpath, filename), "r", encoding="utf-8")
-				data = json.load(f)
-				f.close()
-				if self._config.container_filename == filename:
-					# First level of dirpath is a container if container_list passed
-					if container_list is None or ('/' in dirpath[len(directory)+1:] or '\\' in dirpath[len(directory)+1:]):
-						if folder_list is not None:
-							folder_list.append(data)
+				if filename.endswith('.json'):
+					f = open(os.path.join(dirpath, filename), "r", encoding="utf-8")
+					data = json.load(f)
+					f.close()
+					if self._config.container_filename == filename:
+						# First level of dirpath is a container if container_list passed
+						if container_list is None or ('/' in dirpath[len(directory)+1:] or '\\' in dirpath[len(directory)+1:]):
+							if folder_list is not None:
+								folder_list.append(data)
+						else:
+							container_list.append(data)
 					else:
-						container_list.append(data)
-				else:
-					object_list.append(data)
+						object_list.append(data)
+				elif filename.endswith('.sql'):
+					try:
+						entity_data = next(filter(lambda x: x['path'][-1] == filename.replace('.sql', ''), object_list))
+						with open(os.path.join(dirpath, filename), 'r') as f:
+							entity_data['sql'] = f.read()
+					except StopIteration as e: 
+						raise Exception(f"The entity data was not found for {filename.replace('.sql', '')}, does the {filename.replace('.sql', '.json')} exist?")
+						
+
 
 	def _write_container_json_file(self, root_dir, container):
 		filepath = os.path.join(root_dir, container['name'], self._config.container_filename).encode(encoding='utf-8', errors='strict')
@@ -357,24 +370,42 @@ class DremioFile():
 		f.close()
 
 
+	def _build_path(self, root_dir, path_parts, file_extension):
+		sanitized_path_parts = [self._replace_special_characters(path_part) for path_part in path_parts]
+		sanitized_path_parts[-1] = sanitized_path_parts[-1] + file_extension
+
+		path = pathlib.Path(root_dir)
+		for part in sanitized_path_parts:
+			path = path / part
+
+		return path
+		
+
+	def _write_entity_sql_file(self, root_dir, entity):
+		# check if any folder needs to be created
+		path_parts = entity['path']
+		filepath = self._build_path(root_dir=root_dir, path_parts=path_parts, file_extension=".sql")
+		filepath.parent.mkdir(parents=True, exist_ok=True)
+
+		with filepath.open('w', encoding="utf-8") as f:
+			f.write(entity['sql'])
+
+
 	def _write_entity_json_file(self, root_dir, entity):
 		# check if any folder needs to be created
-		path = entity['path']
-		filepath = root_dir
-		for item in path:
-			if not os.path.isdir(filepath.encode(encoding='utf-8', errors='strict')):
-				try:
-					os.makedirs(filepath.encode(encoding='utf-8', errors='strict'))
-				except OSError as e:
-					if e.errno != errno.EEXIST:
-						raise "Cannot create directory: " + filepath
-			# Replace special characters with underscore
-			filepath = os.path.join(filepath, self._replace_special_characters(item))
-		# write entity into json file
-		filepath = (filepath  + ".json").encode(encoding='utf-8', errors='strict')
-		f = open(filepath, "w", encoding="utf-8")
-		json.dump(entity, f, indent=4, sort_keys=True)
-		f.close()
+		path_parts = entity['path']
+		filepath = self._build_path(root_dir=root_dir, path_parts=path_parts, file_extension=".json")
+		filepath.parent.mkdir(parents=True, exist_ok=True)
+		
+		
+		# remove the sql, because that will be saved in a separate file
+		entity_data = copy.copy(entity)
+		if 'sql' in entity_data:
+			del entity_data['sql']
+
+		with filepath.open('w', encoding="utf-8") as f:
+			json.dump(entity_data, f, indent=4, sort_keys=True)
+			
 
 
 	def _replace_special_characters(self, fs_item):


### PR DESCRIPTION
We use dremio-cloner to add all our VDS definitions under source control. So we can develop on a dev/test environment. Do peer reviews and finally sync the repository to the production environment. 

In this workflow it's really hard to do PR reviews on VDS changes. As the most important change is the 'SQL' query and in the repository that query is hidden in a JSON file as a single line string. It's near impossible to review those changes. 

You would need to go to the production environment web-ui. Copy the SQL code into a file. Copy the version from test. Do a diff to see the changes. If it looks ok you can then execute the new query to validate the results. 

By splitting up the SQL from the JSON file you get the opportunity to have meaning full diffs in PR's and with the right kind of tools you could even execute the VDS query directly from your code editor to do the testing. 